### PR TITLE
Set brand.js to UltiBlocks.

### DIFF
--- a/src/lib/brand.js
+++ b/src/lib/brand.js
@@ -1,5 +1,5 @@
 // Legacy export format because this is used by some build-time scripts stuck in the past.
 // eslint-disable-next-line import/no-commonjs
 module.exports = {
-    APP_NAME: 'TurboWarp'
+    APP_NAME: 'UltiBlocks'
 };


### PR DESCRIPTION
### Resolves

I assume that rule doesn't apply in this Scratch fork?

### Proposed Changes

Set brand.js to UltiBlocks, which makes a bunch of things say UltiBlocks instead of TurboWarp.
![Screenshot 2025-02-05 at 07-13-23 UltiBlocks Editor](https://github.com/user-attachments/assets/4eef2b8c-906e-43ce-8f0c-bd91cdee7d4f)

### Reason for Changes

Because why should we call this fork TurboWarp?

### Test Coverage

No need.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
